### PR TITLE
TRP3 Compatibility

### DIFF
--- a/Display/CreatureTextMSP.lua
+++ b/Display/CreatureTextMSP.lua
@@ -12,7 +12,7 @@ end
 local frame = CreateFrame("Frame")
 frame:RegisterEvent("PLAYER_LOGIN")
 frame:SetScript("OnEvent", function()
-  if msp and msp_RPAddOn then
+  if msp and msp_RPAddOn and not TRP3_Platynator then
     table.insert(msp.callback.updated, MSPCallback)
 
     msp_RPNameplatesAddOn = "Platynator"

--- a/Display/Initialize.lua
+++ b/Display/Initialize.lua
@@ -6,6 +6,10 @@ function addonTable.Display.Initialize()
   local manager = CreateFrame("Frame")
   Mixin(manager, addonTable.Display.ManagerMixin)
   manager:OnLoad()
+
+  function Platynator_GetDisplayByUnit(unit)
+    return manager.nameplateDisplays[unit]
+  end
 end
 
 addonTable.Display.ManagerMixin = {}
@@ -217,6 +221,8 @@ function addonTable.Display.ManagerMixin:OnLoad()
         end
         self:UpdateNamePlateSize()
         self:UpdateStacking()
+
+        EventRegistry:TriggerEvent("Platynator.DesignChanged"); --For other addons
       end)
     elseif state[addonTable.Constants.RefreshReason.Scale] or state[addonTable.Constants.RefreshReason.TargetBehaviour] then
       for unit, display in pairs(self.nameplateDisplays) do


### PR DESCRIPTION
### 1. Global API to Acquire Platynator Display
- Added a global API to allow other addons to get the Display with unit token.
- TRP3 users can set up their RP names, custom titles, and character icons, all of which are important player identities.
- If we can acquire the `Platynator Display`, then TRP3 can manage the aforementioned features on its own.

### 2. Notify Design Changes
- Trigger an event through WoW's EventRegistry to notify other addons that the current Platynator Design has changed.
- So that other addons know they should re-process all nameplates.

Thank you for your time, plusmouse 🫡 