### PR TITLE
feat: allow to flip icon widgets

### DIFF
--- a/CustomiseDialog/Designer.lua
+++ b/CustomiseDialog/Designer.lua
@@ -822,6 +822,11 @@ function addonTable.CustomiseDialog.GetMainDesigner(parent)
         end
         if w.details.kind == "castIcon" and w.details.square then
           w.background:Show()
+          local flip = w.details.flip or {}
+          addonTable.Display.UpdateTextureFlip(w.marker, flip.horizontal, 0.1, 0.9, 0.1, 0.9)
+        else
+          local flip = w.details.flip or {}
+          addonTable.Display.UpdateTextureFlip(w.marker, flip.horizontal)
         end
       elseif w.kind == "highlights" then
         w:Show(true)

--- a/CustomiseDialog/WidgetsConfiguration.lua
+++ b/CustomiseDialog/WidgetsConfiguration.lua
@@ -547,6 +547,16 @@ addonTable.CustomiseDialog.WidgetsConfig = {
               return details.color
             end,
           },
+          {
+            label = addonTable.Locales.FLIP,
+            kind = "checkbox",
+            setter = function(details, value)
+              details.flip = { horizontal = value }
+            end,
+            getter = function(details)
+              return details.flip and details.flip.horizontal
+            end,
+          },
         },
       },
     },

--- a/Display/CannotInterruptMarker.lua
+++ b/Display/CannotInterruptMarker.lua
@@ -50,4 +50,7 @@ function addonTable.Display.CannotInterruptMarkerMixin:ApplyCasting()
   else
     self.marker:Hide()
   end
+  
+  local flip = self.details.flip or {}
+  addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal)
 end

--- a/Display/CastIconMarker.lua
+++ b/Display/CastIconMarker.lua
@@ -88,4 +88,11 @@ function addonTable.Display.CastIconMarkerMixin:ApplyCasting()
       self.background:Hide()
     end
   end
+  
+  local flip = self.details.flip or {}
+  if self.details.square then
+    addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal, 0.1, 0.9, 0.1, 0.9)
+  else
+    addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal)
+  end
 end

--- a/Display/EliteMarker.lua
+++ b/Display/EliteMarker.lua
@@ -28,6 +28,10 @@ function addonTable.Display.EliteMarkerMixin:SetUnit(unit)
     else
       self.marker:Hide()
     end
+    
+    local flip = self.details.flip or {}
+    addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal, flip.vertical)
+
   else
     self:Strip()
   end

--- a/Display/PvPMarker.lua
+++ b/Display/PvPMarker.lua
@@ -56,4 +56,7 @@ function addonTable.Display.PvPMarkerMixin:Update()
   else
     self.marker:Hide()
   end
+  
+  local flip = self.details.flip or {}
+  addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal)
 end

--- a/Display/QuestMarker.lua
+++ b/Display/QuestMarker.lua
@@ -19,6 +19,9 @@ end
 
 function addonTable.Display.QuestMarkerMixin:UpdateMarker()
   self.marker:SetShown(C_QuestLog.UnitIsRelatedToActiveQuest and C_QuestLog.UnitIsRelatedToActiveQuest(self.unit))
+  
+  local flip = self.details.flip or {}
+  addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal)
 end
 
 function addonTable.Display.QuestMarkerMixin:OnEvent(eventName, ...)

--- a/Display/RaidMarker.lua
+++ b/Display/RaidMarker.lua
@@ -32,4 +32,7 @@ function addonTable.Display.RaidMarkerMixin:UpdateMarker()
   else
     self.marker:Hide()
   end
+  
+  local flip = self.details.flip or {}
+  addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal)
 end

--- a/Display/RareMarker.lua
+++ b/Display/RareMarker.lua
@@ -12,6 +12,9 @@ function addonTable.Display.RareMarkerMixin:SetUnit(unit)
     else
       self.marker:Hide()
     end
+    
+    local flip = self.details.flip or {}
+    addonTable.Display.UpdateTextureFlip(self.marker, flip.horizontal)
   else
     self:Strip()
   end

--- a/Display/Utilities.lua
+++ b/Display/Utilities.lua
@@ -66,3 +66,28 @@ function addonTable.Display.Utilities.IsInRelevantInstance()
   local _, instanceType = GetInstanceInfo()
   return instanceType == "raid" or instanceType == "party" or instanceType == "arenas"
 end
+
+function addonTable.Display.UpdateTextureFlip(texture, flipHorizontal, minU, maxU, minV, maxV)
+  local ULx, ULy, LLx, LLy, URx, URy, LRx, LRy
+  
+  if minU then
+    ULx, ULy = minU, minV
+    LLx, LLy = minU, maxV
+    URx, URy = maxU, minV
+    LRx, LRy = maxU, maxV
+  else
+    ULx, ULy, LLx, LLy, URx, URy, LRx, LRy = texture:GetTexCoord()
+  end
+  
+  local left = math.min(ULx, LLx, URx, LRx)
+  local right = math.max(ULx, LLx, URx, LRx)
+  if flipHorizontal then
+     ULx, LLx = right, right
+     URx, LRx = left, left
+  else
+     ULx, LLx = left, left
+     URx, LRx = right, right
+  end
+  
+  texture:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy)
+end

--- a/Locales.lua
+++ b/Locales.lua
@@ -108,6 +108,8 @@ L["DIFFICULTY"] = "Difficulty"
 L["AUTOMATIC"] = "Automatic"
 L["SHOW_NAMEPLATES_ONLY_IF_NEEDED"] = "Show nameplates only if needed"
 L["NEVER"] = "Never"
+
+L["FLIP"] = "Flip"
 L["NAME_ONLY_PLAYERS"] = "Name only (players)"
 L["ALWAYS_ALL"] = "Always (all)"
 L["ON_TARGET_SCALE"] = "On target scale"


### PR DESCRIPTION
Allows the flipping icon widgets.

Nice for e.g the rare/elite icon
<img width="609" height="566" alt="grafik" src="https://github.com/user-attachments/assets/06a0f7be-98a5-444d-8744-654b8190c817" />
