### PR TITLE
Fix: display supercharged combo points (UNIT_POWER_POINT_CHARGE)

### DIFF
--- a/Display/Initialize.lua
+++ b/Display/Initialize.lua
@@ -78,6 +78,9 @@ function addonTable.Display.ManagerMixin:OnLoad()
 
   self:RegisterUnitEvent("UNIT_POWER_UPDATE", "player")
   self:RegisterEvent("RUNE_POWER_UPDATE")
+  if addonTable.Constants.IsRetail and C_EventUtils.IsEventValid("UNIT_POWER_POINT_CHARGE") then
+    self:RegisterUnitEvent("UNIT_POWER_POINT_CHARGE", "player")
+  end
   self:RegisterEvent("UNIT_FACTION")
   self:RegisterEvent("PLAYER_REGEN_DISABLED")
   self:RegisterEvent("PLAYER_REGEN_ENABLED")
@@ -825,7 +828,7 @@ function addonTable.Display.ManagerMixin:OnEvent(eventName, ...)
     else
       self.lastInteract = nil
     end
-  elseif eventName == "UNIT_POWER_UPDATE" or eventName == "RUNE_POWER_UPDATE" then
+  elseif eventName == "UNIT_POWER_UPDATE" or eventName == "RUNE_POWER_UPDATE" or eventName == "UNIT_POWER_POINT_CHARGE" then
     for _, display in pairs(self.nameplateDisplays) do
       display:UpdateForTarget()
     end

--- a/Display/PowerBar.lua
+++ b/Display/PowerBar.lua
@@ -79,6 +79,8 @@ local specializationToColor = {
   [1473] = CreateColorFromRGBHexString("37e5fc"),
 }
 
+local chargeColor = CreateColorFromRGBHexString("00aaff")
+
 local powerKind, powerColor, powerDivisor, specID
 
 local specializationMonitor = CreateFrame("Frame")
@@ -207,6 +209,12 @@ function addonTable.Display.PowerBarMixin:SetValue(currentPower, maxPower, color
   end
 
   if maxPower > 0 then
+    local chargedPoints = GetUnitChargedPowerPoints and GetUnitChargedPowerPoints("player") or nil
+    for i = 1, maxPower do
+      local c = (chargedPoints and tContains(chargedPoints, i)) and chargeColor or color
+      self.powerTextures[i]:SetVertexColor(c.r, c.g, c.b)
+    end
+
     if self.powerTextures[1].SetSpriteSheetCell then
       for i = 1, maxPower do
         self.powerTextures[i]:SetSpriteSheetCell(i <= currentPower and 1 or 2, 1, 2)


### PR DESCRIPTION
## Problem
The power bar did not display supercharged combo points (e.g. from Supercharger, spell 470347), because the addon had no handling for the `UNIT_POWER_POINT_CHARGE` event nor the `GetUnitChargedPowerPoints` API.

## Solution
- **PowerBar.lua**: on each update, call `GetUnitChargedPowerPoints("player")` and color any charged pip blue (`#00aaff`), leaving normal pips unchanged
- **Initialize.lua**: register `UNIT_POWER_POINT_CHARGE` (retail only) and trigger `UpdateForTarget()` on all displays when it fires

<img width="466" height="421" alt="image" src="https://github.com/user-attachments/assets/6a3395f5-dddc-493d-94b5-70cad977b9ad" />
