### PR TITLE
feat(guild): add guild name filter to Guild text widget

### DIFF
--- a/CustomiseDialog/Designer.lua
+++ b/CustomiseDialog/Designer.lua
@@ -521,6 +521,195 @@ local function GetAurasTextPositioning(rootParent, iconID)
   return container
 end
 
+-- [ADDED] GetGuildNameFilter
+-- Builds the UI control for the "Guild name" filter option that appears under
+-- the VALUES section of the Guild text widget in the Customise dialog.
+--
+-- Layout (all inside a single holder frame):
+--
+--   [collapsed, 40 px tall]
+--   ┌─────────────────────────────────────┐
+--   │  Guild name          [✓] checkbox   │
+--   └─────────────────────────────────────┘
+--
+--   [expanded, 120 px tall — shown when checkbox is checked]
+--   ┌─────────────────────────────────────┐
+--   │  Guild name          [✓] checkbox   │
+--   ├─────────────────────────────────────┤
+--   │  [Equal to ▾] dropdown              │  ← operator picker
+--   ├─────────────────────────────────────┤
+--   │  [________________] edit box        │  ← guild name to match
+--   └─────────────────────────────────────┘
+--
+-- The value stored in details.guildNameFilter is a plain table:
+--   { enabled = bool, operator = string, value = string }
+--
+-- Whenever any control changes, the callback (Setter in GenerateOptions) is
+-- called with a copy of the current table, which persists it to the design.
+--
+-- @param parent    Frame   The section container provided by GenerateOptions
+-- @param callback  func    Called with the updated filter table on every change
+-- @return          Frame   The holder frame (implements :SetValue(table|nil))
+local function GetGuildNameFilter(parent, callback)
+  local COLLAPSED_HEIGHT = 40   -- height when checkbox is unchecked
+  local EXPANDED_HEIGHT   = 120 -- height when checkbox is checked (40 + 40 + 40)
+
+  -- Outer holder — stacks with other entries via GenerateOptions point logic.
+  local holder = CreateFrame("Frame", nil, parent)
+  holder:SetPoint("LEFT", parent, "LEFT", 30, 0)
+  holder:SetPoint("RIGHT", parent, "RIGHT", -15, 0)
+  holder:SetHeight(COLLAPSED_HEIGHT)
+
+  -- ── Row 1: label + checkbox ──────────────────────────────────────────────
+  -- Mirrors the layout produced by Components.GetCheckbox so it visually
+  -- aligns with the Player guild / NPC role checkboxes above it.
+  local label = holder:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+  label:SetPoint("LEFT", holder, "LEFT", 0, 10)
+  label:SetPoint("RIGHT", holder, "CENTER", -50, 10)
+  label:SetJustifyH("RIGHT")
+  label:SetText(addonTable.Locales.GUILD_NAME_FILTER)
+
+  local checkBox = CreateFrame("CheckButton", nil, holder, "SettingsCheckboxTemplate")
+  checkBox:SetPoint("LEFT", holder, "CENTER", -43, 10)
+
+  -- ── Sub-frame: operator dropdown + value editbox ─────────────────────────
+  -- Anchored just below row 1. Hidden by default; shown when checkbox is
+  -- checked and the holder expands to EXPANDED_HEIGHT.
+  local subFrame = CreateFrame("Frame", nil, holder)
+  subFrame:SetPoint("TOPLEFT", holder, "TOPLEFT", 0, -COLLAPSED_HEIGHT)
+  subFrame:SetPoint("RIGHT", holder, "RIGHT", 0, 0)
+  subFrame:SetHeight(80)
+  subFrame:Hide()
+
+  -- Row 2: operator dropdown (uses the same WowStyle1 template as the rest
+  -- of the addon's dropdowns).
+  local opDropdown = CreateFrame("DropdownButton", nil, subFrame, "WowStyle1DropdownTemplate")
+  opDropdown:SetWidth(160)
+  opDropdown:SetPoint("LEFT", subFrame, "LEFT", 30, -10)
+
+  -- All supported operators. The "value" field is the key stored in
+  -- details.guildNameFilter.operator and evaluated by MatchesGuildFilter()
+  -- in GuildText.lua.
+  local operators = {
+    { label = addonTable.Locales.FILTER_OP_EQUAL_TO,     value = "equalTo"    },
+    { label = addonTable.Locales.FILTER_OP_BEGINS_WITH,  value = "beginsWith" },
+    { label = addonTable.Locales.FILTER_OP_ENDS_WITH,    value = "endsWith"   },
+    { label = addonTable.Locales.FILTER_OP_CONTAINS,     value = "contains"   },
+    { label = addonTable.Locales.FILTER_OP_NOT_EQUAL_TO, value = "notEqualTo" },
+  }
+
+  -- currentData is a live copy of details.guildNameFilter. All controls read
+  -- and mutate this table; FireCallback() then hands it to the Setter so the
+  -- design is updated and nameplates refresh.
+  local currentData = nil
+
+  local function FireCallback()
+    if currentData then
+      callback(currentData)
+    end
+  end
+
+  -- Build the operator radio menu. CreateRadio needs:
+  --   isSelected(value) → bool   used to tick the active option on open
+  --   onSelected(value)          called when the user picks an option
+  opDropdown:SetupMenu(function(_, rootDescription)
+    for _, op in ipairs(operators) do
+      rootDescription:CreateRadio(
+        op.label,
+        function(val) return currentData and currentData.operator == val end,
+        function(val)
+          if currentData then
+            currentData.operator = val
+            FireCallback()
+          end
+        end,
+        op.value
+      )
+    end
+  end)
+
+  -- Row 3: guild name EditBox, inset-framed to match WoW's input style.
+  local editBoxContainer = CreateFrame("Frame", nil, subFrame, "InsetFrameTemplate")
+  editBoxContainer:SetPoint("LEFT", subFrame, "LEFT", 30, 0)
+  editBoxContainer:SetPoint("RIGHT", subFrame, "RIGHT", -15, 0)
+  editBoxContainer:SetPoint("TOP", opDropdown, "BOTTOM", 0, -4)
+  editBoxContainer:SetHeight(28)
+
+  local editBox = CreateFrame("EditBox", nil, editBoxContainer)
+  editBox:SetFontObject(GameFontHighlight)
+  editBox:SetPoint("LEFT",   editBoxContainer, "LEFT",   6,  0)
+  editBox:SetPoint("RIGHT",  editBoxContainer, "RIGHT",  -6, 0)
+  editBox:SetPoint("TOP",    editBoxContainer, "TOP",    0,  -2)
+  editBox:SetPoint("BOTTOM", editBoxContainer, "BOTTOM", 0,   2)
+  editBox:SetAutoFocus(false)
+  editBox:SetMaxLetters(64)
+
+  -- Save on Enter or on focus loss; revert on Escape.
+  editBox:SetScript("OnEnterPressed", function(self)
+    self:ClearFocus()
+    if currentData then
+      currentData.value = self:GetText()
+      FireCallback()
+    end
+  end)
+  editBox:SetScript("OnEscapePressed", function(self)
+    self:ClearFocus()
+    -- Revert the displayed text to whatever was last saved.
+    if currentData then self:SetText(currentData.value or "") end
+  end)
+  editBox:SetScript("OnEditFocusLost", function(self)
+    -- Catches clicks away from the box (tab, clicking elsewhere, etc.).
+    if currentData then
+      currentData.value = self:GetText()
+      FireCallback()
+    end
+  end)
+
+  -- ── Expand / collapse helper ─────────────────────────────────────────────
+  -- Changing holder:SetHeight() causes downstream frames (anchored to this
+  -- frame's BOTTOM) to reflow automatically — no scroll box rebuild needed.
+  local function SetExpanded(expanded)
+    if expanded then
+      holder:SetHeight(EXPANDED_HEIGHT)
+      subFrame:Show()
+    else
+      holder:SetHeight(COLLAPSED_HEIGHT)
+      subFrame:Hide()
+    end
+  end
+
+  -- ── Checkbox click ───────────────────────────────────────────────────────
+  checkBox:SetScript("OnClick", function(self)
+    local enabled = self:GetChecked()
+    -- Initialise currentData on first use so the other fields have defaults.
+    if not currentData then
+      currentData = { enabled = false, operator = "equalTo", value = "" }
+    end
+    currentData.enabled = enabled
+    SetExpanded(enabled)
+    FireCallback()
+  end)
+
+  -- ── SetValue (called by UpdateOptions when the panel is shown / refreshed) ─
+  -- Receives details.guildNameFilter (table or nil).
+  function holder:SetValue(value)
+    -- Work with a local copy so we don't mutate the design table directly.
+    currentData = value and CopyTable(value) or nil
+    local enabled = currentData and currentData.enabled or false
+    checkBox:SetChecked(enabled)
+    SetExpanded(enabled)
+    if currentData then
+      -- Regenerate the dropdown so the correct operator is highlighted.
+      opDropdown:GenerateMenu()
+      editBox:SetText(currentData.value or "")
+    else
+      editBox:SetText("")
+    end
+  end
+
+  return holder
+end
+
 GenerateOptions = function(parent, yOffset, xOffset, entries)
   local allFrames = {}
 
@@ -575,6 +764,9 @@ GenerateOptions = function(parent, yOffset, xOffset, entries)
       frame = GetAutomaticColors(parent, e.lockedElements, e.addAlpha)
     elseif e.kind == "auraTextsPositioner" then
       frame = GetAurasTextPositioning(parent, e.icon)
+    -- [ADDED] Guild name filter — custom expanding control (see GetGuildNameFilter above)
+    elseif e.kind == "guildNameFilter" then
+      frame = GetGuildNameFilter(parent, Setter)
     end
 
     if frame then

--- a/CustomiseDialog/WidgetsConfiguration.lua
+++ b/CustomiseDialog/WidgetsConfiguration.lua
@@ -806,6 +806,30 @@ addonTable.CustomiseDialog.WidgetsConfig = {
               return details.npcRole
             end,
           },
+
+          -- [ADDED] Guild Name Filter entry
+          -- Renders a custom "guildNameFilter" control (see Designer.lua:
+          -- GetGuildNameFilter). When the user checks the checkbox, two extra
+          -- controls expand below it:
+          --   1. A dropdown to pick the comparison operator
+          --      ("Equal to", "Begins with", "Ends with", "Contains", "Not equal to")
+          --   2. An EditBox where the user types the guild name to match against.
+          --
+          -- The saved value is a table stored in details.guildNameFilter:
+          --   { enabled = bool, operator = string, value = string }
+          --
+          -- When enabled = false (or the field is nil), GuildText.lua ignores
+          -- the filter entirely — fully backwards-compatible with existing designs.
+          {
+            label = addonTable.Locales.GUILD_NAME_FILTER,
+            kind = "guildNameFilter",
+            setter = function(details, value)
+              details.guildNameFilter = value
+            end,
+            getter = function(details)
+              return details.guildNameFilter
+            end,
+          },
         }
       }
     },

--- a/Display/GuildText.lua
+++ b/Display/GuildText.lua
@@ -18,6 +18,41 @@ if not C_TooltipInfo then
   tooltip = CreateFrame("GameTooltip", "PlatynatorUnitGuildTooltip", nil, "GameTooltipTemplate")
 end
 
+-- [ADDED] Guild Name Filter
+-- Evaluates whether a guild name satisfies the user-configured filter condition.
+-- Called before displaying the guild name on a nameplate; if the filter is active
+-- and the guild does not match, the text is suppressed (defaultText stays "").
+--
+-- @param guild   string  The guild name retrieved via GetGuildInfo()
+-- @param filter  table|nil  details.guildNameFilter:
+--                  { enabled = bool, operator = string, value = string }
+--                  operator values: "equalTo" | "beginsWith" | "endsWith"
+--                                   "contains" | "notEqualTo"
+-- @return bool   true = show the guild name, false = suppress it
+local function MatchesGuildFilter(guild, filter)
+  -- If no filter is configured, or the checkbox is unchecked, always show.
+  if not filter or not filter.enabled then return true end
+
+  local text = filter.value or ""
+  -- An empty filter value is treated as "no restriction" — always show.
+  if text == "" then return true end
+
+  -- If we somehow have no guild string at this point, suppress to be safe.
+  if not guild or guild == "" then return false end
+
+  local op = filter.operator or "equalTo"
+
+  if     op == "equalTo"    then return guild == text
+  elseif op == "beginsWith" then return guild:sub(1, #text) == text
+  elseif op == "endsWith"   then return #text == 0 or guild:sub(-#text) == text
+  elseif op == "contains"   then return guild:find(text, 1, true) ~= nil
+  elseif op == "notEqualTo" then return guild ~= text
+  end
+
+  -- Unknown operator — default to showing.
+  return true
+end
+
 addonTable.Display.GuildTextMixin = {}
 
 function addonTable.Display.GuildTextMixin:SetUnit(unit)
@@ -27,7 +62,11 @@ function addonTable.Display.GuildTextMixin:SetUnit(unit)
     if UnitIsPlayer(self.unit) then
       if self.details.playerGuild then
         local guild = GetGuildInfo(self.unit)
-        if guild then
+        -- [ADDED] Only set the guild name as the display text if it passes the
+        -- user's guild name filter (details.guildNameFilter). When no filter is
+        -- set (or the checkbox is unchecked), MatchesGuildFilter returns true and
+        -- behaviour is identical to the original code.
+        if guild and MatchesGuildFilter(guild, self.details.guildNameFilter) then
           self.defaultText = guild
         end
       end

--- a/Locales.lua
+++ b/Locales.lua
@@ -280,6 +280,17 @@ L["MULTIPLE_VALUES_DISPLAY"] = "Multiple values display"
 L["INCLUDE_ELITE_RARES"] = "Include elite rares"
 L["PLAYER_GUILD"] = "Player guild"
 L["NPC_ROLE"] = "NPC role"
+
+-- [ADDED] Guild Name Filter — locale strings for the new guild name filter
+-- feature on the Guild text widget (Values section).
+-- All other languages fall back to these enUS strings automatically via the
+-- locale merge in Core/Locales.lua.
+L["GUILD_NAME_FILTER"]      = "Guild name"       -- checkbox label under Values
+L["FILTER_OP_EQUAL_TO"]     = "Equal to"         -- operator dropdown options
+L["FILTER_OP_BEGINS_WITH"]  = "Begins with"
+L["FILTER_OP_ENDS_WITH"]    = "Ends with"
+L["FILTER_OP_CONTAINS"]     = "Contains"
+L["FILTER_OP_NOT_EQUAL_TO"] = "Not equal to"
 L["INCLUDE_TARGET"] = "Include target"
 L["ANIMATE"] = "Animate"
 L["ENABLE_IF_LINES_FALLING_OFF_FONT"] = "Enable if lines falling off font"


### PR DESCRIPTION
Under the Guild widget's Values section, a new "Guild name" entry lets users filter nameplate guild text by a typed string and a comparison operator. The control is collapsed by default (checkbox only) and expands to reveal a dropdown + edit box when enabled.

Changes:
- Locales.lua: add GUILD_NAME_FILTER and five FILTER_OP_* strings (enUS; other locales fall back automatically via the existing merge in Core/Locales.lua).

- CustomiseDialog/WidgetsConfiguration.lua: register the new "guildNameFilter" entry in the guild widget VALUES section. Its getter/setter persist { enabled, operator, value } in details.guildNameFilter.

- CustomiseDialog/Designer.lua: add GetGuildNameFilter(), a self-contained UI component that expands from 40 px (checkbox row) to 120 px (checkbox
  + operator dropdown + EditBox) when the user enables the filter. Wired into GenerateOptions via a new elseif e.kind == "guildNameFilter" branch.

- Display/GuildText.lua: add MatchesGuildFilter(guild, filter) and call it in SetUnit() before setting defaultText. Supported operators: equalTo, beginsWith, endsWith, contains, notEqualTo. No filter / empty value / disabled flag all pass through unchanged (fully backwards-compatible).